### PR TITLE
Add install options to prevent unplanned reboot and allow vc14 to exit if existing version found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is used to list changes made in each version of vcruntime.
 
 ## Unreleased
 
+- add norestart options to installers [@derekgroh](https://github.com/derekgroh)
+- add returns 1638 to `vc14` [@derekgroh](https://github.com/derekgroh)
+
 ## 2.1.0 - *2021-01-15*
 
 - Add GitHub Actions CI/CD. [@derekGroh](https://github.com/derekgroh)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Versions in the same recipe replace prior versions except for Microsoft Visual C
 | Microsoft Visual C++ 2013 | 12.0.0501<br>12.0.0660.0 |
 | Microsoft Visual C++ 2015 | 14.0.3026.0<br>14.0.4123.0<br>14.0.4212.0<br>14.0.24215 |
 | Microsoft Visual C++ 2017 | 14.0.25017.0<br>14.4.26429.4 |
-| Microsoft Visual C++ 2015-2019 | 14.27.29016.0 |
+| Microsoft Visual C++ 2015-2019 | 14.28.29325.2 |
 
 ## Usage
 
@@ -72,7 +72,7 @@ Include the default recipe to install all supported versions:
 }
 ```
 
-Include `vcruntime::vc6`, `vcruntime::vc9`, `vcruntime::vc10`, `vcruntime::vc11`, `vcruntime::vc12`, or `vcruntime::vc14` in your node's `run_list` to install specific versions only:
+Include `vcruntime::vc6`, `vcruntime::vc9`, `vcruntime::vc10`, `vcruntime::vc11`, `vcruntime::vc12`, or `vcruntime::vc14` in your node's `run_list` to install specific versions only or `vcruntime::default` for all versions:
 
 ```json
 {

--- a/recipes/vc10.rb
+++ b/recipes/vc10.rb
@@ -30,7 +30,7 @@ if platform?('windows')
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc10']['x64'][node['vcruntime']['vc10']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc10']['x64'][node['vcruntime']['vc10']['version']]['sha256sum'],
       })
-      options '/q'
+      options '/q /norestart'
     end
     windows_package node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['name'] do
       checksum node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['sha256sum']
@@ -41,7 +41,7 @@ if platform?('windows')
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['sha256sum'],
       })
-      options '/q'
+      options '/q /norestart'
     end
   when /i[3-6]86/
     windows_package node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['name'] do
@@ -53,7 +53,7 @@ if platform?('windows')
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['sha256sum'],
       })
-      options '/q'
+      options '/q /norestart'
     end
   end
 end

--- a/recipes/vc11.rb
+++ b/recipes/vc11.rb
@@ -30,7 +30,7 @@ if platform?('windows')
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc11']['x64'][node['vcruntime']['vc11']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc11']['x64'][node['vcruntime']['vc11']['version']]['sha256sum'],
       })
-      options '/q'
+      options '/install /quiet /norestart'
     end
     windows_package node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['name'] do
       checksum node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['sha256sum']
@@ -41,7 +41,7 @@ if platform?('windows')
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['sha256sum'],
       })
-      options '/q'
+      options '/install /quiet /norestart'
     end
   when /i[3-6]86/
     windows_package node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['name'] do
@@ -53,7 +53,7 @@ if platform?('windows')
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['sha256sum'],
       })
-      options '/q'
+      options '/install /quiet /norestart'
     end
   end
 end

--- a/recipes/vc12.rb
+++ b/recipes/vc12.rb
@@ -30,7 +30,7 @@ if platform?('windows')
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc12']['x64'][node['vcruntime']['vc12']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc12']['x64'][node['vcruntime']['vc12']['version']]['sha256sum'],
       })
-      options '/q'
+      options '/install /quiet /norestart'
     end
     windows_package node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['name'] do
       checksum node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['sha256sum']
@@ -41,7 +41,7 @@ if platform?('windows')
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['sha256sum'],
       })
-      options '/q'
+      options '/install /quiet /norestart'
     end
   when /i[3-6]86/
     windows_package node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['name'] do
@@ -53,7 +53,7 @@ if platform?('windows')
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['sha256sum'],
       })
-      options '/q'
+      options '/install /quiet /norestart'
     end
   end
 end

--- a/recipes/vc14.rb
+++ b/recipes/vc14.rb
@@ -30,7 +30,7 @@ if platform?('windows')
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc14']['x64'][node['vcruntime']['vc14']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc14']['x64'][node['vcruntime']['vc14']['version']]['sha256sum'],
       })
-      options '/q'
+      options '/install /quiet /norestart'
     end
     windows_package node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['name'] do
       checksum node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['sha256sum']
@@ -41,7 +41,7 @@ if platform?('windows')
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['sha256sum'],
       })
-      options '/q'
+      options '/install /quiet /norestart'
     end
   when /i[3-6]86/
     windows_package node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['name'] do
@@ -53,7 +53,7 @@ if platform?('windows')
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['sha256sum'],
       })
-      options '/q'
+      options '/install /quiet /norestart'
     end
   end
 end

--- a/recipes/vc14.rb
+++ b/recipes/vc14.rb
@@ -25,7 +25,7 @@ if platform?('windows')
       checksum node['vcruntime']['vc14']['x64'][node['vcruntime']['vc14']['version']]['sha256sum']
       source node['vcruntime']['vc14']['x64'][node['vcruntime']['vc14']['version']]['url']
       installer_type :custom
-      returns [0, 3010]
+      returns [0, 1638, 3010]
       remote_file_attributes({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc14']['x64'][node['vcruntime']['vc14']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc14']['x64'][node['vcruntime']['vc14']['version']]['sha256sum'],
@@ -36,7 +36,7 @@ if platform?('windows')
       checksum node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['sha256sum']
       source node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['url']
       installer_type :custom
-      returns [0, 3010]
+      returns [0, 1638, 3010]
       remote_file_attributes({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['sha256sum'],
@@ -48,7 +48,7 @@ if platform?('windows')
       checksum node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['sha256sum']
       source node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['url']
       installer_type :custom
-      returns [0, 3010]
+      returns [0, 1638, 3010]
       remote_file_attributes({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['sha256sum'],


### PR DESCRIPTION
# Description

Adds additional install options to prevent reboot and exit code 1638 as valid for vc14 (2015-2019 installs)

## Issues Resolved

#30, #36, #37

## Check List

- [X] All tests pass. See TESTING.md for details.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
