### PR TITLE
Updated checksums for 14.28.29325.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file is used to list changes made in each version of vcruntime.
 
 ## Unreleased
+
 - updated checksums for 14.28.29325.2 [@SAPDanJoe](https://github.com/SAPDanJoe)
 
 ## 2.2.0 - *2021-01-16*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This file is used to list changes made in each version of vcruntime.
 
 ## Unreleased
+- updated checksums for 14.28.29325.2 [@SAPDanJoe](https://github.com/SAPDanJoe)
 
 ## 2.2.0 - *2021-01-16*
 

--- a/attributes/vc14.rb
+++ b/attributes/vc14.rb
@@ -63,10 +63,10 @@ default['vcruntime']['vc14']['x64']['14.14.26429.4']['name']      = 'Microsoft V
 
 # Microsoft Visual C++ 2019 Redistributable
 default['vcruntime']['vc14']['x86']['14.28.29325.2']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x86.exe'
-default['vcruntime']['vc14']['x86']['14.28.29325.2']['sha256sum'] = '50a3e92ade4c2d8f310a2812d46322459104039b9deadbd7fdd483b5c697c0c8'
+default['vcruntime']['vc14']['x86']['14.28.29325.2']['sha256sum'] = 'E830C313AA99656748F9D2ED582C28101EAAF75F5377E3FB104C761BF3F808B2'
 default['vcruntime']['vc14']['x86']['14.28.29325.2']['name']      = 'Microsoft Visual C++ 2019 Redistributable (x86) - 14.28.29325.2'
 default['vcruntime']['vc14']['x64']['14.28.29325.2']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x64.exe'
-default['vcruntime']['vc14']['x64']['14.28.29325.2']['sha256sum'] = 'b1a32c71a6b7d5978904fb223763263ea5a7eb23b2c44a0d60e90d234ad99178'
+default['vcruntime']['vc14']['x64']['14.28.29325.2']['sha256sum'] = '015EDD4E5D36E053B23A01ADB77A2B12444D3FB6ECCEFE23E3A8CD6388616A16'
 default['vcruntime']['vc14']['x64']['14.28.29325.2']['name']      = 'Microsoft Visual C++ 2019 Redistributable (x64) - 14.28.29325.2'
 
 default['vcruntime']['vc14']['version'] = '14.28.29325.2'

--- a/attributes/vc14.rb
+++ b/attributes/vc14.rb
@@ -63,10 +63,10 @@ default['vcruntime']['vc14']['x64']['14.14.26429.4']['name']      = 'Microsoft V
 
 # Microsoft Visual C++ 2019 Redistributable
 default['vcruntime']['vc14']['x86']['14.28.29325.2']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x86.exe'
-default['vcruntime']['vc14']['x86']['14.28.29325.2']['sha256sum'] = 'E830C313AA99656748F9D2ED582C28101EAAF75F5377E3FB104C761BF3F808B2'
+default['vcruntime']['vc14']['x86']['14.28.29325.2']['sha256sum'] = 'e830c313aa99656748f9d2ed582c28101eaaf75f5377e3fb104c761bf3f808b2'
 default['vcruntime']['vc14']['x86']['14.28.29325.2']['name']      = 'Microsoft Visual C++ 2019 Redistributable (x86) - 14.28.29325.2'
 default['vcruntime']['vc14']['x64']['14.28.29325.2']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x64.exe'
-default['vcruntime']['vc14']['x64']['14.28.29325.2']['sha256sum'] = '015EDD4E5D36E053B23A01ADB77A2B12444D3FB6ECCEFE23E3A8CD6388616A16'
+default['vcruntime']['vc14']['x64']['14.28.29325.2']['sha256sum'] = '015edd4e5d36e053b23a01adb77a2b12444d3fb6eccefe23e3a8cd6388616a16'
 default['vcruntime']['vc14']['x64']['14.28.29325.2']['name']      = 'Microsoft Visual C++ 2019 Redistributable (x64) - 14.28.29325.2'
 
 default['vcruntime']['vc14']['version'] = '14.28.29325.2'


### PR DESCRIPTION
# Description

Cookbook is able to download 14.28.29325.2

## Issues Resolved

cookbook was not able to download 14.28.29325.2 due to checksum mismatch

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
