### PR TITLE
vc14 package - 2019-04-19 - 14.28.29914.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of vcruntime.
 
 ## Unreleased
 
+- Update vc14 checksum for '14.28.29914.0' [@derekgroh](https://github.com/derekgroh)
+
 ## 2.2.0 - *2021-01-16*
 
 - add norestart options to installers [@derekgroh](https://github.com/derekgroh)

--- a/attributes/vc14.rb
+++ b/attributes/vc14.rb
@@ -62,11 +62,11 @@ default['vcruntime']['vc14']['x64']['14.14.26429.4']['sha256sum'] = '9abf3a13865
 default['vcruntime']['vc14']['x64']['14.14.26429.4']['name']      = 'Microsoft Visual C++ 2017 Redistributable (x64) - 14.14.26429'
 
 # Microsoft Visual C++ 2019 Redistributable
-default['vcruntime']['vc14']['x86']['14.28.29325.2']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x86.exe'
-default['vcruntime']['vc14']['x86']['14.28.29325.2']['sha256sum'] = '50a3e92ade4c2d8f310a2812d46322459104039b9deadbd7fdd483b5c697c0c8'
-default['vcruntime']['vc14']['x86']['14.28.29325.2']['name']      = 'Microsoft Visual C++ 2019 Redistributable (x86) - 14.28.29325.2'
-default['vcruntime']['vc14']['x64']['14.28.29325.2']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x64.exe'
-default['vcruntime']['vc14']['x64']['14.28.29325.2']['sha256sum'] = 'b1a32c71a6b7d5978904fb223763263ea5a7eb23b2c44a0d60e90d234ad99178'
-default['vcruntime']['vc14']['x64']['14.28.29325.2']['name']      = 'Microsoft Visual C++ 2019 Redistributable (x64) - 14.28.29325.2'
+default['vcruntime']['vc14']['x86']['14.28.29914.0']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x86.exe'
+default['vcruntime']['vc14']['x86']['14.28.29914.0']['sha256sum'] = '14563755ac24a874241935ef2c22c5fce973acb001f99e524145113b2dc638c1'
+default['vcruntime']['vc14']['x86']['14.28.29914.0']['name']      = 'Microsoft Visual C++ 2019 Redistributable (x86) - 14.28.29914.0'
+default['vcruntime']['vc14']['x64']['14.28.29914.0']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x64.exe'
+default['vcruntime']['vc14']['x64']['14.28.29914.0']['sha256sum'] = '52b196bbe9016488c735e7b41805b651261ffa5d7aa86eb6a1d0095be83687b2'
+default['vcruntime']['vc14']['x64']['14.28.29914.0']['name']      = 'Microsoft Visual C++ 2019 Redistributable (x64) - 14.28.29914.0'
 
-default['vcruntime']['vc14']['version'] = '14.28.29325.2'
+default['vcruntime']['vc14']['version'] = '14.28.29914.0'

--- a/test/integration/vc14/vc14_test.rb
+++ b/test/integration/vc14/vc14_test.rb
@@ -10,7 +10,7 @@ control 'Microsoft Visual C++ Redistributable (x86)' do
                'Microsoft Visual C++ 2015 x86 Additional Runtime - 14.0.24215' => '14.0.24215',
                'Microsoft Visual C++ 2017 Redistributable (x86) - 14.10.25017' => '14.10.25017.0',
                'Microsoft Visual C++ 2017 Redistributable (x86) - 14.14.26429' => '14.14.26429.4',
-               'Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.28.29325' => '14.28.29325.2' }
+               'Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.28.29914' => '14.28.29914.0' }
   describe.one do
     packages.each do |name, version|
       describe package(name.to_s) do
@@ -28,7 +28,7 @@ control 'Microsoft Visual C++ Redistributable (x64)' do
                'Microsoft Visual C++ 2015 x64 Additional Runtime - 14.0.24215' => '14.0.24215',
                'Microsoft Visual C++ 2017 Redistributable (x64) - 14.10.25017' => '14.10.25017.0',
                'Microsoft Visual C++ 2017 Redistributable (x64) - 14.14.26429' => '14.14.26429.4',
-               'Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.28.29325' => '14.28.29325.2' }
+               'Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.28.29914' => '14.28.29914.0' }
   describe.one do
     packages.each do |name, version|
       describe package(name.to_s) do


### PR DESCRIPTION
# Description

Matches the checksum for vc14 packages as they are updated on a static link, invalidating older configuration.

## Issues Resolved

None, same PR intent as https://github.com/sous-chefs/vcruntime/pull/39

## Check List

- [X] All tests pass. See TESTING.md for details.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
