### PR TITLE
vc6 package 2021-05-18 - 6.0.2900.2180

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of vcruntime.
 
 ## Unreleased
 
+- Update vc6,vc9,vc10 checksums [@derekgroh](https://github.com/derekgroh)
+
 ## 2.2.1 - *2021-04-20*
 
 - Update vc14 checksum for '14.28.29914.0' [@derekgroh](https://github.com/derekgroh)

--- a/attributes/vc10.rb
+++ b/attributes/vc10.rb
@@ -18,17 +18,17 @@
 # limitations under the License.
 
 default['vcruntime']['vc10']['x86']['10.0.30319']['url']       = 'http://download.microsoft.com/download/5/B/C/5BC5DBB3-652D-4DCE-B14A-475AB85EEF6E/vcredist_x86.exe'
-default['vcruntime']['vc10']['x86']['10.0.30319']['sha256sum'] = '8162b2d665ca52884507ede19549e99939ce4ea4a638c537fa653539819138c8'
+default['vcruntime']['vc10']['x86']['10.0.30319']['sha256sum'] = '31d32fa39d52cac9a765a43660431f7a127eee784b54b2f5e2af3e2b763a1af8'
 default['vcruntime']['vc10']['x86']['10.0.30319']['name']      = 'Microsoft Visual C++ 2010  x86 Redistributable - 10.0.30319'
 default['vcruntime']['vc10']['x64']['10.0.30319']['url']       = 'http://download.microsoft.com/download/3/2/2/3224B87F-CFA0-4E70-BDA3-3DE650EFEBA5/vcredist_x64.exe'
-default['vcruntime']['vc10']['x64']['10.0.30319']['sha256sum'] = 'b06546ddc8ca1e3d532f3f2593e88a6f49e81b66a9c2051d58508cc97b6a2023'
+default['vcruntime']['vc10']['x64']['10.0.30319']['sha256sum'] = '3ced60e566e9c74806db8739663b27d06012cc6b6ee5b28eaa2afce5514bcacf'
 default['vcruntime']['vc10']['x64']['10.0.30319']['name']      = 'Microsoft Visual C++ 2010  x64 Redistributable - 10.0.30319'
 
 default['vcruntime']['vc10']['x86']['10.0.40219']['url']       = 'http://download.microsoft.com/download/C/6/D/C6D0FD4E-9E53-4897-9B91-836EBA2AACD3/vcredist_x86.exe'
-default['vcruntime']['vc10']['x86']['10.0.40219']['sha256sum'] = '66b797b3b4f99488f53c2b676610dfe9868984c779536891a8d8f73ee214bc4b'
+default['vcruntime']['vc10']['x86']['10.0.40219']['sha256sum'] = '19c6d6e24901177d73528a28b0f13563ae5674b81f93cf466673ccc4c38ce828'
 default['vcruntime']['vc10']['x86']['10.0.40219']['name']      = 'Microsoft Visual C++ 2010  x86 Redistributable - 10.0.40219'
 default['vcruntime']['vc10']['x64']['10.0.40219']['url']       = 'http://download.microsoft.com/download/A/8/0/A80747C3-41BD-45DF-B505-E9710D2744E0/vcredist_x64.exe'
-default['vcruntime']['vc10']['x64']['10.0.40219']['sha256sum'] = 'c6cd2d3f0b11dc2a604ffdc4dd97861a83b77e21709ba71b962a47759c93f4c8'
+default['vcruntime']['vc10']['x64']['10.0.40219']['sha256sum'] = '2fddbc3aaaab784c16bc673c3bae5f80929d5b372810dbc28649283566d33255'
 default['vcruntime']['vc10']['x64']['10.0.40219']['name']      = 'Microsoft Visual C++ 2010  x64 Redistributable - 10.0.40219'
 
 default['vcruntime']['vc10']['version'] = '10.0.40219'

--- a/attributes/vc6.rb
+++ b/attributes/vc6.rb
@@ -18,10 +18,10 @@
 # limitations under the License.
 
 default['vcruntime']['vc6']['x86']['6.0.2900.2180']['url']       = 'https://download.microsoft.com/download/8/B/4/8B42259F-5D70-43F4-AC2E-4B208FD8D66A/vcredist_x86.EXE'
-default['vcruntime']['vc6']['x86']['6.0.2900.2180']['sha256sum'] = '4ee4da0fe62d5fa1b5e80c6e6d88a4a2f8b3b140c35da51053d0d7b72a381d29'
+default['vcruntime']['vc6']['x86']['6.0.2900.2180']['sha256sum'] = '8648c5fc29c44b9112fe52f9a33f80e7fc42d10f3b5b42b2121542a13e44adfd'
 default['vcruntime']['vc6']['x86']['6.0.2900.2180']['name']      = 'Microsoft Visual C++ 2005 Redistributable'
 default['vcruntime']['vc6']['x64']['6.0.2900.2180']['url']       = 'https://download.microsoft.com/download/8/B/4/8B42259F-5D70-43F4-AC2E-4B208FD8D66A/vcredist_x64.EXE'
-default['vcruntime']['vc6']['x64']['6.0.2900.2180']['sha256sum'] = '0551a61c85b718e1fa015b0c3e3f4c4eea0637055536c00e7969286b4fa663e0'
+default['vcruntime']['vc6']['x64']['6.0.2900.2180']['sha256sum'] = '4487570bd86e2e1aac29db2a1d0a91eb63361fcaac570808eb327cd4e0e2240d'
 default['vcruntime']['vc6']['x64']['6.0.2900.2180']['name']      = 'Microsoft Visual C++ 2005 Redistributable (x64)'
 
 default['vcruntime']['vc6']['version'] = '6.0.2900.2180'

--- a/attributes/vc9.rb
+++ b/attributes/vc9.rb
@@ -25,10 +25,10 @@ default['vcruntime']['vc9']['x64']['9.0.21022.8']['sha256sum'] = 'baaaeddc17bcda
 default['vcruntime']['vc9']['x64']['9.0.21022.8']['name']      = 'Microsoft Visual C++ 2008 Redistributable - x64 9.0.21022'
 
 default['vcruntime']['vc9']['x86']['9.0.30729.5677']['url']       = 'https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe'
-default['vcruntime']['vc9']['x86']['9.0.30729.5677']['sha256sum'] = '6b3e4c51c6c0e5f68c8a72b497445af3dbf976394cbb62aa23569065c28deeb6'
+default['vcruntime']['vc9']['x86']['9.0.30729.5677']['sha256sum'] = '8742bcbf24ef328a72d2a27b693cc7071e38d3bb4b9b44dec42aa3d2c8d61d92'
 default['vcruntime']['vc9']['x86']['9.0.30729.5677']['name']      = 'Microsoft Visual C++ 2008 Redistributable - x86 9.0.30729.6161'
 default['vcruntime']['vc9']['x64']['9.0.30729.5677']['url']       = 'https://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x64.exe'
-default['vcruntime']['vc9']['x64']['9.0.30729.5677']['sha256sum'] = 'b811f2c047a3e828517c234bd4aa4883e1ec591d88fad21289ae68a6915a6665'
+default['vcruntime']['vc9']['x64']['9.0.30729.5677']['sha256sum'] = 'c5e273a4a16ab4d5471e91c7477719a2f45ddadb76c7f98a38fa5074a6838654'
 default['vcruntime']['vc9']['x64']['9.0.30729.5677']['name']      = 'Microsoft Visual C++ 2008 Redistributable - x64 9.0.30729.6161'
 
 default['vcruntime']['vc9']['version'] = '9.0.30729.5677'


### PR DESCRIPTION
# Description

Hash for vc6 runtimes have been updated at the provides links, cookbook will fail to download the files because the checksum no longer matches.

## Issues Resolved

#42 

## Check List

- [X] All tests pass. See TESTING.md for details.