### PR TITLE
vc14 14.29.30037 package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of vcruntime.
 
 ## Unreleased
 
+- Update vc14 checksum for '14.29.30037.0' [@jhboricua](https://github.com/jhboricua)
+
 ## 2.2.2 - *2021-05-18*
 
 - Update vc6,vc9,vc10 checksums [@derekgroh](https://github.com/derekgroh)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Versions in the same recipe replace prior versions except for Microsoft Visual C
 | Microsoft Visual C++ 2013 | 12.0.0501<br>12.0.0660.0 |
 | Microsoft Visual C++ 2015 | 14.0.3026.0<br>14.0.4123.0<br>14.0.4212.0<br>14.0.24215 |
 | Microsoft Visual C++ 2017 | 14.0.25017.0<br>14.4.26429.4 |
-| Microsoft Visual C++ 2015-2019 | 14.28.29325.2 |
+| Microsoft Visual C++ 2015-2019 | 14.29.30037.0 |
 
 ## Usage
 

--- a/attributes/vc14.rb
+++ b/attributes/vc14.rb
@@ -62,11 +62,11 @@ default['vcruntime']['vc14']['x64']['14.14.26429.4']['sha256sum'] = '9abf3a13865
 default['vcruntime']['vc14']['x64']['14.14.26429.4']['name']      = 'Microsoft Visual C++ 2017 Redistributable (x64) - 14.14.26429'
 
 # Microsoft Visual C++ 2019 Redistributable
-default['vcruntime']['vc14']['x86']['14.28.29914.0']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x86.exe'
-default['vcruntime']['vc14']['x86']['14.28.29914.0']['sha256sum'] = '14563755ac24a874241935ef2c22c5fce973acb001f99e524145113b2dc638c1'
-default['vcruntime']['vc14']['x86']['14.28.29914.0']['name']      = 'Microsoft Visual C++ 2019 Redistributable (x86) - 14.28.29914.0'
-default['vcruntime']['vc14']['x64']['14.28.29914.0']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x64.exe'
-default['vcruntime']['vc14']['x64']['14.28.29914.0']['sha256sum'] = '52b196bbe9016488c735e7b41805b651261ffa5d7aa86eb6a1d0095be83687b2'
-default['vcruntime']['vc14']['x64']['14.28.29914.0']['name']      = 'Microsoft Visual C++ 2019 Redistributable (x64) - 14.28.29914.0'
+default['vcruntime']['vc14']['x64']['14.29.30037.0']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x86.exe'
+default['vcruntime']['vc14']['x64']['14.29.30037.0']['sha256sum'] = '91c21c93a88dd82e8ae429534dacbc7a4885198361eae18d82920c714e328cf9'
+default['vcruntime']['vc14']['x64']['14.29.30037.0']['name']      = 'Microsoft Visual C++ 2019 Redistributable (x86) - 14.29.30037'
+default['vcruntime']['vc14']['x64']['14.29.30037.0']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x64.exe'
+default['vcruntime']['vc14']['x64']['14.29.30037.0']['sha256sum'] = 'a1592d3da2b27230c087a3b069409c1e82c2664b0d4c3b511701624702b2e2a3'
+default['vcruntime']['vc14']['x64']['14.29.30037.0']['name']      = 'Microsoft Visual C++ 2019 Redistributable (x64) - 14.29.30037'
 
-default['vcruntime']['vc14']['version'] = '14.28.29914.0'
+default['vcruntime']['vc14']['version'] = '14.29.30037.0'

--- a/attributes/vc14.rb
+++ b/attributes/vc14.rb
@@ -62,9 +62,9 @@ default['vcruntime']['vc14']['x64']['14.14.26429.4']['sha256sum'] = '9abf3a13865
 default['vcruntime']['vc14']['x64']['14.14.26429.4']['name']      = 'Microsoft Visual C++ 2017 Redistributable (x64) - 14.14.26429'
 
 # Microsoft Visual C++ 2019 Redistributable
-default['vcruntime']['vc14']['x64']['14.29.30037.0']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x86.exe'
-default['vcruntime']['vc14']['x64']['14.29.30037.0']['sha256sum'] = '91c21c93a88dd82e8ae429534dacbc7a4885198361eae18d82920c714e328cf9'
-default['vcruntime']['vc14']['x64']['14.29.30037.0']['name']      = 'Microsoft Visual C++ 2019 Redistributable (x86) - 14.29.30037'
+default['vcruntime']['vc14']['x86']['14.29.30037.0']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x86.exe'
+default['vcruntime']['vc14']['x86']['14.29.30037.0']['sha256sum'] = '91c21c93a88dd82e8ae429534dacbc7a4885198361eae18d82920c714e328cf9'
+default['vcruntime']['vc14']['x86']['14.29.30037.0']['name']      = 'Microsoft Visual C++ 2019 Redistributable (x86) - 14.29.30037'
 default['vcruntime']['vc14']['x64']['14.29.30037.0']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x64.exe'
 default['vcruntime']['vc14']['x64']['14.29.30037.0']['sha256sum'] = 'a1592d3da2b27230c087a3b069409c1e82c2664b0d4c3b511701624702b2e2a3'
 default['vcruntime']['vc14']['x64']['14.29.30037.0']['name']      = 'Microsoft Visual C++ 2019 Redistributable (x64) - 14.29.30037'

--- a/test/integration/vc14/vc14_test.rb
+++ b/test/integration/vc14/vc14_test.rb
@@ -10,7 +10,7 @@ control 'Microsoft Visual C++ Redistributable (x86)' do
                'Microsoft Visual C++ 2015 x86 Additional Runtime - 14.0.24215' => '14.0.24215',
                'Microsoft Visual C++ 2017 Redistributable (x86) - 14.10.25017' => '14.10.25017.0',
                'Microsoft Visual C++ 2017 Redistributable (x86) - 14.14.26429' => '14.14.26429.4',
-               'Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.28.29914' => '14.28.29914.0' }
+               'Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30037' => '14.29.30037.0' }
   describe.one do
     packages.each do |name, version|
       describe package(name.to_s) do
@@ -28,7 +28,7 @@ control 'Microsoft Visual C++ Redistributable (x64)' do
                'Microsoft Visual C++ 2015 x64 Additional Runtime - 14.0.24215' => '14.0.24215',
                'Microsoft Visual C++ 2017 Redistributable (x64) - 14.10.25017' => '14.10.25017.0',
                'Microsoft Visual C++ 2017 Redistributable (x64) - 14.14.26429' => '14.14.26429.4',
-               'Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.28.29914' => '14.28.29914.0' }
+               'Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.29.30037' => '14.29.30037.0' }
   describe.one do
     packages.each do |name, version|
       describe package(name.to_s) do


### PR DESCRIPTION
Signed-off-by: Jose Hernandez <jhboricua@gmail.com>

# Description

Updates vc14 checksum for newly released 14.29.30037 package

## Issues Resolved

Cookbook not downloading vc14 package due to checksum mistmatch

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
