### PR TITLE
new vc14 package - 14.29.30133

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of vcruntime.
 
 ## Unreleased
 
+- Update vc14 checksum for new release 14.29.30133.0 [@jhboricua](https://github.com/jhboricua)
+
 ## 2.2.6 - *2021-08-31*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Versions in the same recipe replace prior versions except for Microsoft Visual C
 | Microsoft Visual C++ 2013 | 12.0.0501<br>12.0.0660.0 |
 | Microsoft Visual C++ 2015 | 14.0.3026.0<br>14.0.4123.0<br>14.0.4212.0<br>14.0.24215 |
 | Microsoft Visual C++ 2017 | 14.0.25017.0<br>14.4.26429.4 |
-| Microsoft Visual C++ 2015-2019 | 14.29.30037.0 |
+| Microsoft Visual C++ 2015-2019 | 14.29.30133.0 |
 
 ## Usage
 

--- a/attributes/vc14.rb
+++ b/attributes/vc14.rb
@@ -63,10 +63,10 @@ default['vcruntime']['vc14']['x64']['14.14.26429.4']['name']      = 'Microsoft V
 
 # Microsoft Visual C++ 2019 Redistributable
 default['vcruntime']['vc14']['x86']['14.29.30037.0']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x86.exe'
-default['vcruntime']['vc14']['x86']['14.29.30037.0']['sha256sum'] = '91c21c93a88dd82e8ae429534dacbc7a4885198361eae18d82920c714e328cf9'
-default['vcruntime']['vc14']['x86']['14.29.30037.0']['name']      = 'Microsoft Visual C++ 2019 X86 Minimum Runtime - 14.29.30037'
+default['vcruntime']['vc14']['x86']['14.29.30037.0']['sha256sum'] = '1acd8d5ea1cdc3eb2eb4c87be3ab28722d0825c15449e5c9ceef95d897de52fa'
+default['vcruntime']['vc14']['x86']['14.29.30037.0']['name']      = 'Microsoft Visual C++ 2019 X86 Minimum Runtime - 14.29.30133'
 default['vcruntime']['vc14']['x64']['14.29.30037.0']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x64.exe'
-default['vcruntime']['vc14']['x64']['14.29.30037.0']['sha256sum'] = 'a1592d3da2b27230c087a3b069409c1e82c2664b0d4c3b511701624702b2e2a3'
-default['vcruntime']['vc14']['x64']['14.29.30037.0']['name']      = 'Microsoft Visual C++ 2019 X64 Minimum Runtime - 14.29.30037'
+default['vcruntime']['vc14']['x64']['14.29.30037.0']['sha256sum'] = '003063723b2131da23f40e2063fb79867bae275f7b5c099dbd1792e25845872b'
+default['vcruntime']['vc14']['x64']['14.29.30037.0']['name']      = 'Microsoft Visual C++ 2019 X64 Minimum Runtime - 14.29.30133'
 
 default['vcruntime']['vc14']['version'] = '14.29.30037.0'

--- a/test/integration/vc14/vc14_test.rb
+++ b/test/integration/vc14/vc14_test.rb
@@ -10,7 +10,7 @@ control 'Microsoft Visual C++ Redistributable (x86)' do
                'Microsoft Visual C++ 2015 x86 Additional Runtime - 14.0.24215' => '14.0.24215',
                'Microsoft Visual C++ 2017 Redistributable (x86) - 14.10.25017' => '14.10.25017.0',
                'Microsoft Visual C++ 2017 Redistributable (x86) - 14.14.26429' => '14.14.26429.4',
-               'Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30037' => '14.29.30037.0' }
+               'Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30133' => '14.29.30133.0' }
   describe.one do
     packages.each do |name, version|
       describe package(name.to_s) do
@@ -28,7 +28,7 @@ control 'Microsoft Visual C++ Redistributable (x64)' do
                'Microsoft Visual C++ 2015 x64 Additional Runtime - 14.0.24215' => '14.0.24215',
                'Microsoft Visual C++ 2017 Redistributable (x64) - 14.10.25017' => '14.10.25017.0',
                'Microsoft Visual C++ 2017 Redistributable (x64) - 14.14.26429' => '14.14.26429.4',
-               'Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.29.30037' => '14.29.30037.0' }
+               'Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.29.30133' => '14.29.30133.0' }
   describe.one do
     packages.each do |name, version|
       describe package(name.to_s) do


### PR DESCRIPTION
Signed-off-by: Jose Hernandez <jhboricua@gmail.com>

# Description

Adds new sha256 checksum for newer vc14 package.

## Issues Resolved

vcruntime cookbook fails due to vc14 checksum not matching newer vc14 release

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
