### PR TITLE
Adding checksums for new releases of vc14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of vcruntime.
 
 ## Unreleased
 
+- Update vc14 checksum for new releases of 2015-2019 and 2015-2022 runtimes [@jhboricua](https://github.com/jhboricua)
+
 ## 2.2.7 - *2021-09-23*
 
 - Update vc14 checksum for new release 14.29.30133.0 [@jhboricua](https://github.com/jhboricua)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Versions in the same recipe replace prior versions except for Microsoft Visual C
 | Microsoft Visual C++ 2013 | 12.0.0501<br>12.0.0660.0 |
 | Microsoft Visual C++ 2015 | 14.0.3026.0<br>14.0.4123.0<br>14.0.4212.0<br>14.0.24215 |
 | Microsoft Visual C++ 2017 | 14.0.25017.0<br>14.4.26429.4 |
-| Microsoft Visual C++ 2015-2019 | 14.29.30133.0 |
+| Microsoft Visual C++ 2015-2019 | 14.29.30135.0 |
+| Microsoft Visual C++ 2015-2022 | 14.30.30704.0 |
 
 ## Usage
 

--- a/attributes/vc14.rb
+++ b/attributes/vc14.rb
@@ -62,11 +62,19 @@ default['vcruntime']['vc14']['x64']['14.14.26429.4']['sha256sum'] = '9abf3a13865
 default['vcruntime']['vc14']['x64']['14.14.26429.4']['name']      = 'Microsoft Visual C++ 2017 Redistributable (x64) - 14.14.26429'
 
 # Microsoft Visual C++ 2019 Redistributable
-default['vcruntime']['vc14']['x86']['14.29.30037.0']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x86.exe'
-default['vcruntime']['vc14']['x86']['14.29.30037.0']['sha256sum'] = '1acd8d5ea1cdc3eb2eb4c87be3ab28722d0825c15449e5c9ceef95d897de52fa'
-default['vcruntime']['vc14']['x86']['14.29.30037.0']['name']      = 'Microsoft Visual C++ 2019 X86 Minimum Runtime - 14.29.30133'
-default['vcruntime']['vc14']['x64']['14.29.30037.0']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x64.exe'
-default['vcruntime']['vc14']['x64']['14.29.30037.0']['sha256sum'] = '003063723b2131da23f40e2063fb79867bae275f7b5c099dbd1792e25845872b'
-default['vcruntime']['vc14']['x64']['14.29.30037.0']['name']      = 'Microsoft Visual C++ 2019 X64 Minimum Runtime - 14.29.30133'
+default['vcruntime']['vc14']['x86']['14.29.30135.0']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x86.exe'
+default['vcruntime']['vc14']['x86']['14.29.30135.0']['sha256sum'] = '80c7969f4e05002a0cd820b746e0acb7406d4b85e52ef096707315b390927824'
+default['vcruntime']['vc14']['x86']['14.29.30135.0']['name']      = 'Microsoft Visual C++ 2019 X86 Minimum Runtime - 14.29.30135'
+default['vcruntime']['vc14']['x64']['14.29.30135.0']['url']       = 'https://aka.ms/vs/16/release/vc_redist.x64.exe'
+default['vcruntime']['vc14']['x64']['14.29.30135.0']['sha256sum'] = '9b9dd72c27ab1db081de56bb7b73bee9a00f60d14ed8e6fde45dab3e619b5f04'
+default['vcruntime']['vc14']['x64']['14.29.30135.0']['name']      = 'Microsoft Visual C++ 2019 X64 Minimum Runtime - 14.29.30135'
 
-default['vcruntime']['vc14']['version'] = '14.29.30037.0'
+# Microsoft Visual C++ 2022 Redistributable
+default['vcruntime']['vc14']['x86']['14.30.30704.0']['url']       = 'https://aka.ms/vs/17/release/vc_redist.x86.exe'
+default['vcruntime']['vc14']['x86']['14.30.30704.0']['sha256sum'] = 'ac75a82d873e6b6f98b1d293042380764d7d263c43438e50d564fa58c9f891c2'
+default['vcruntime']['vc14']['x86']['14.30.30704.0']['name']      = 'Microsoft Visual C++ 2022 X86 Minimum Runtime - 14.30.30704'
+default['vcruntime']['vc14']['x64']['14.30.30704.0']['url']       = 'https://aka.ms/vs/17/release/vc_redist.x64.exe'
+default['vcruntime']['vc14']['x64']['14.30.30704.0']['sha256sum'] = 'a9f5d2eaf67bf0db0178b6552a71c523c707df0e2cc66c06bfbc08bdc53387e7'
+default['vcruntime']['vc14']['x64']['14.30.30704.0']['name']      = 'Microsoft Visual C++ 2022 X64 Minimum Runtime - 14.30.30704'
+
+default['vcruntime']['vc14']['version'] = '14.30.30704.0'

--- a/test/integration/default/default_test.rb
+++ b/test/integration/default/default_test.rb
@@ -21,7 +21,8 @@ control 'Microsoft Visual C++ Redistributable (x86)' do
                'Microsoft Visual C++ 2015 x86 Additional Runtime - 14.0.24215' => '14.0.24215',
                'Microsoft Visual C++ 2017 Redistributable (x86) - 14.10.25017' => '14.10.25017.0',
                'Microsoft Visual C++ 2017 Redistributable (x86) - 14.14.26429' => '14.14.26429.4',
-               'Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.28.29325' => '14.28.29325.2' }
+               'Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30135' => '14.29.30135.0',
+               'Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.30.30704' => '14.30.30704.0' }
   describe.one do
     packages.each do |name, version|
       describe package(name.to_s) do
@@ -50,7 +51,8 @@ control 'Microsoft Visual C++ Redistributable (x64)' do
                'Microsoft Visual C++ 2015 x64 Additional Runtime - 14.0.24215' => '14.0.24215',
                'Microsoft Visual C++ 2017 Redistributable (x64) - 14.10.25017' => '14.10.25017.0',
                'Microsoft Visual C++ 2017 Redistributable (x64) - 14.14.26429' => '14.14.26429.4',
-               'Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.28.29325' => '14.28.29325.2' }
+               'Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.29.30135' => '14.29.30135.0',
+               'Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.30.30704' => '14.30.30704.0' }
   describe.one do
     packages.each do |name, version|
       describe package(name.to_s) do

--- a/test/integration/vc14/vc14_test.rb
+++ b/test/integration/vc14/vc14_test.rb
@@ -10,7 +10,8 @@ control 'Microsoft Visual C++ Redistributable (x86)' do
                'Microsoft Visual C++ 2015 x86 Additional Runtime - 14.0.24215' => '14.0.24215',
                'Microsoft Visual C++ 2017 Redistributable (x86) - 14.10.25017' => '14.10.25017.0',
                'Microsoft Visual C++ 2017 Redistributable (x86) - 14.14.26429' => '14.14.26429.4',
-               'Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30133' => '14.29.30133.0' }
+               'Microsoft Visual C++ 2015-2019 Redistributable (x86) - 14.29.30135' => '14.29.30135.0',
+               'Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.30.30704' => '14.30.30704.0' }
   describe.one do
     packages.each do |name, version|
       describe package(name.to_s) do
@@ -28,7 +29,8 @@ control 'Microsoft Visual C++ Redistributable (x64)' do
                'Microsoft Visual C++ 2015 x64 Additional Runtime - 14.0.24215' => '14.0.24215',
                'Microsoft Visual C++ 2017 Redistributable (x64) - 14.10.25017' => '14.10.25017.0',
                'Microsoft Visual C++ 2017 Redistributable (x64) - 14.14.26429' => '14.14.26429.4',
-               'Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.29.30133' => '14.29.30133.0' }
+               'Microsoft Visual C++ 2015-2019 Redistributable (x64) - 14.29.30135' => '14.29.30135.0',
+               'Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.30.30704' => '14.30.30704.0' }
   describe.one do
     packages.each do |name, version|
       describe package(name.to_s) do


### PR DESCRIPTION
# Description

* Adds checksum for new release of Visual Studio 2015-2019 runtimes
* Adds checksum for new release of Visual Studio 2015-2022 runtimes

## Issues Resolved

Package version and checksum must be updated every time Microsoft releases an update to avoid cookbook failure to run on new installations.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
