### PR TITLE
chore: migrate to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+name 'vcruntime'
+
+run_list 'vcruntime::default'
+
+cookbook 'vcruntime', path: '.'
+
+named_run_list :default, 'vcruntime::default'
+named_run_list :all,
+               'vcruntime::vc6',
+               'vcruntime::vc9',
+               'vcruntime::vc10',
+               'vcruntime::vc11',
+               'vcruntime::vc12',
+               'vcruntime::vc14'
+named_run_list :vc6, 'vcruntime::vc6'
+named_run_list :vc9, 'vcruntime::vc9'
+named_run_list :vc10, 'vcruntime::vc10'
+named_run_list :vc11, 'vcruntime::vc11'
+named_run_list :vc12, 'vcruntime::vc12'
+named_run_list :vc14, 'vcruntime::vc14'

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,8 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
+# Dependency cache #
+####################
 cookbooks/*
 tmp
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -6,8 +6,9 @@ transport:
   elevated: true
 
 provisioner:
-  name: chef_zero
+  name: policyfile_zero
   deprecations_as_errors: true
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec
@@ -26,49 +27,44 @@ platforms:
 
 suites:
   - name: all
-    run_list:
-      - recipe[vcruntime::vc6]
-      - recipe[vcruntime::vc9]
-      - recipe[vcruntime::vc10]
-      - recipe[vcruntime::vc11]
-      - recipe[vcruntime::vc12]
-      - recipe[vcruntime::vc14]
+    provisioner:
+      named_run_list: all
     verifier:
       inspec_tests:
         - test/integration/default
   - name: vc6
-    run_list:
-      - recipe[vcruntime::vc6]
+    provisioner:
+      named_run_list: vc6
     verifier:
       inspec_tests:
         - test/integration/vc6
   - name: vc9
-    run_list:
-      - recipe[vcruntime::vc9]
+    provisioner:
+      named_run_list: vc9
     verifier:
       inspec_tests:
         - test/integration/vc9
   - name: vc10
-    run_list:
-      - recipe[vcruntime::vc10]
+    provisioner:
+      named_run_list: vc10
     verifier:
       inspec_tests:
         - test/integration/vc10
   - name: vc11
-    run_list:
-      - recipe[vcruntime::vc11]
+    provisioner:
+      named_run_list: vc11
     verifier:
       inspec_tests:
         - test/integration/vc11
   - name: vc12
-    run_list:
-      - recipe[vcruntime::vc12]
+    provisioner:
+      named_run_list: vc12
     verifier:
       inspec_tests:
         - test/integration/vc12
   - name: vc14
-    run_list:
-      - recipe[vcruntime::vc14]
+    provisioner:
+      named_run_list: vc14
     verifier:
       inspec_tests:
         - test/integration/vc14

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- replace Berksfile/Berkshelf usage with Policyfile resolution
- switch Kitchen to policyfile_zero and map Windows suites to Policyfile named run lists
- update Copilot setup to install cookbooks with chef install Policyfile.rb

## Verification
- chef install Policyfile.rb
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- /opt/homebrew/bin/markdownlint-cli2 "**/*.md"
- env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH_SYSTEM= /opt/chef-workstation/embedded/bin/rspec --format documentation
- env -u KITCHEN_LOCAL_YAML kitchen list
- env -u KITCHEN_LOCAL_YAML kitchen diagnose vc6-windows-2019

Kitchen note: meaningful suites are Windows Vagrant/WinRM targets, so local Linux Kitchen smoke was intentionally not run.